### PR TITLE
Fix configuration for csharp-ls.csharp-ls-executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [Unreleased]
+- Make sure `csharp-ls.csharp-ls-executable` setting is actually taken into account.
+
 # [0.0.19]
 - [csharp-ls@0.10.0](https://github.com/razzmatazz/csharp-language-server/releases/tag/0.10.0)
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		],
 		"configuration": {
 			"type": "object",
-			"title": "Example configuration",
+			"title": "csharp-ls",
 			"properties": {
 				"csharp-ls.trace.server": {
 					"scope": "window",

--- a/src/cSharpLsServer.ts
+++ b/src/cSharpLsServer.ts
@@ -122,7 +122,7 @@ function shellExec(command: string, args: string[], cwd: string): Promise<string
 }
 
 async function resolveCsharpLsBinaryPath(extensionPath: string,) {
-    const devCsharpLsBinaryPath = workspace.getConfiguration('csharp-ls').get('dev.csharp-ls-executable') as string;
+    const devCsharpLsBinaryPath = workspace.getConfiguration('csharp-ls').get('csharp-ls-executable') as string;
 
     if (devCsharpLsBinaryPath) {
         return devCsharpLsBinaryPath;


### PR DESCRIPTION
Currently configuration schema as defined in package.json does not match what is being queried in code re `csharp-ls.csharp-ls-executable`