### PR TITLE
Add user setting to enable support for .cshtml (razor) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,30 @@ This extension contributes the following settings:
 * `csharp-ls.trace.server`: traces the communication between VS Code and the language server.
 * `csharp-ls.csharp-ls-executable`: Executable path to local csharp-ls. To be used for testing not released csharp-ls version (value: `dotnet /home/user/.../Debug/net7.0/CSharpLanguageServer.dll`). It also can be used for globally installed server via `dotnet tool install --global csharp-ls` (value: `csharp-ls`).
 * `csharp-ls.razor-support`: Enable experimental Razor support for `.cshtml` files. Default is `false`.
+
+## Building from Source
+
+To build the VSIX package for this extension:
+
+1. **Install dependencies** (if you haven't already):
+   ```bash
+   npm install
+   ```
+
+2. **Build the VSIX package**:
+   ```bash
+   npm run build
+   ```
+
+   Or directly:
+   ```bash
+   vsce package
+   ```
+
+This will create a `.vsix` file (e.g., `csharp-ls-0.0.29.vsix`) in the root directory.
+
+### Installing the VSIX
+
+Once built, you can install it via:
+- **Command line**: `code --install-extension csharp-ls-0.0.29.vsix`
+- **VS Code UI**: Extensions → `...` menu → "Install from VSIX..."

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ This extension contributes the following settings:
 
 * `csharp-ls.trace.server`: traces the communication between VS Code and the language server.
 * `csharp-ls.csharp-ls-executable`: Executable path to local csharp-ls. To be used for testing not released csharp-ls version (value: `dotnet /home/user/.../Debug/net7.0/CSharpLanguageServer.dll`). It also can be used for globally installed server via `dotnet tool install --global csharp-ls` (value: `csharp-ls`).
+* `csharp-ls.razor-support`: Enable experimental Razor support for `.cshtml` files. Default is `false`.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,12 @@
 					"type": "string",
 					"default": "",
 					"description": "Executable path to local csharp-ls. To be used for testing not released csharp-ls version (example: `dotnet /home/user/.../Debug/net7.0/CSharpLanguageServer.dll`). It also can be used for globally installed language server via `dotnet tool install --global csharp-ls` (example: `csharp-ls`)."
+				},
+				"csharp-ls.razor-support": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "Enable Razor support in the language server. When enabled, the server will provide language features for .cshtml files."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 					"scope": "window",
 					"type": "boolean",
 					"default": false,
-					"description": "Enable Razor support in the language server. When enabled, the server will provide language features for .cshtml files."
+					"description": "Enable (experimental) Razor support in the language server. When enabled, the server will provide language features for .cshtml files."
 				}
 			}
 		}

--- a/src/cSharpLsServer.ts
+++ b/src/cSharpLsServer.ts
@@ -32,8 +32,16 @@ export async function startCSharpLsServer(
     const rootPath = slnWorkspaceFolder?.uri.fsPath ?? workspace.rootPath ?? '';
     const relativeSolutionPath = solutionPath.replace(rootPath, '').replace(/^[\/\\]/, '');
 
+    // Build features flag
+    const features: string[] = [];
+    const razorSupport = workspace.getConfiguration('csharp-ls').get('razor-support') as boolean;
+    if (razorSupport) {
+        features.push('razor-support');
+    }
+    const featuresFlag = features.length > 0 ? `--features ${features.join(',')}` : '';
+
     const csharpLsExecutable = {
-        command: `${csharpLsBinaryPath} --solution ${relativeSolutionPath}`,
+        command: `${csharpLsBinaryPath} --solution ${relativeSolutionPath} ${featuresFlag}`,
         options: {
             cwd: rootPath,
             shell: true,


### PR DESCRIPTION
This PR adds user setting to enable (experimental) razor-support feature in .cshtml (Razor) files.

NOTE: this is will only work with future 0.22.0 release of csharp-ls, see https://github.com/razzmatazz/csharp-language-server/pull/273