### PR TITLE
Improve configuration middleware and add new settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ If opened folder contains single Solution (.sln) file the language server will b
 
 This extension contributes the following settings:
 
-* `csharp-ls.trace.server`: traces the communication between VS Code and the language server.
+* `csharp-ls.trace.server`: Traces the communication between VS Code and the language server.
 * `csharp-ls.csharp-ls-executable`: Executable path to local csharp-ls. To be used for testing not released csharp-ls version (value: `dotnet /home/user/.../Debug/net7.0/CSharpLanguageServer.dll`). It also can be used for globally installed server via `dotnet tool install --global csharp-ls` (value: `csharp-ls`).
 * `csharp-ls.razor-support`: Enable experimental Razor support for `.cshtml` files. Default is `false`.
+* `csharp-ls.applyFormattingOptions`: Use formatting options as supplied by the editor (may override `.editorconfig` values). Default is `false`.
+* `csharp-ls.analyzersEnabled`: Run Roslyn analyzers (e.g. IDE style rules, third-party NuGet analyzers) as part of diagnostics. Increases diagnostic latency and CPU usage. Default is `false`.
 
 ## Building from Source
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,12 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Run Roslyn analyzers (e.g. IDE style rules, third-party NuGet analyzers) as part of diagnostics. Note: increases diagnostic latency and CPU usage."
+				},
+				"csharp-ls.rpcLog": {
+					"scope": "window",
+					"type": "string",
+					"default": "",
+					"description": "Path to a file where the RPC wire log (READ/WRITE/ERROR messages) will be written (e.g. `~/csharp-ls-rpc.log`). When set, passes `--rpclog <path>` to the csharp-ls binary. Useful for debugging LSP communication issues. Leave empty to disable. Requires a language server restart to take effect."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,18 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Enable (experimental) Razor support in the language server. When enabled, the server will provide language features for .cshtml files."
+				},
+				"csharp-ls.applyFormattingOptions": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "Use formatting options as supplied by the editor (may override .editorconfig values)."
+				},
+				"csharp-ls.analyzersEnabled": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "Run Roslyn analyzers (e.g. IDE style rules, third-party NuGet analyzers) as part of diagnostics. Note: increases diagnostic latency and CPU usage."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,12 @@
 					"type": "string",
 					"default": "",
 					"description": "Path to a file where the RPC wire log (READ/WRITE/ERROR messages) will be written (e.g. `~/csharp-ls-rpc.log`). When set, passes `--rpclog <path>` to the csharp-ls binary. Useful for debugging LSP communication issues. Leave empty to disable. Requires a language server restart to take effect."
+				},
+				"csharp-ls.debugMode": {
+					"scope": "window",
+					"type": "boolean",
+					"default": false,
+					"description": "Enable debug mode in the language server."
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -65,12 +65,6 @@
 					"default": "",
 					"description": "Executable path to local csharp-ls. To be used for testing not released csharp-ls version (example: `dotnet /home/user/.../Debug/net7.0/CSharpLanguageServer.dll`). It also can be used for globally installed language server via `dotnet tool install --global csharp-ls` (example: `csharp-ls`)."
 				},
-				"csharp-ls.razor-support": {
-					"scope": "window",
-					"type": "boolean",
-					"default": false,
-					"description": "Enable (experimental) Razor support in the language server. When enabled, the server will provide language features for .cshtml files."
-				},
 				"csharp-ls.applyFormattingOptions": {
 					"scope": "window",
 					"type": "boolean",

--- a/src/cSharpLsServer.ts
+++ b/src/cSharpLsServer.ts
@@ -2,12 +2,13 @@ import { existsSync } from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { mkdir } from 'fs/promises';
-import { LanguageClient, LanguageClientOptions, ServerOptions, StaticFeature } from 'vscode-languageclient/node';
+import { DidChangeConfigurationNotification, LanguageClient, LanguageClientOptions, ServerOptions, StaticFeature } from 'vscode-languageclient/node';
 import { ChildProcess, spawn } from 'child_process';
-import { ExtensionContext, workspace, window, commands, TextDocumentContentProvider, Uri, languages } from 'vscode';
+import { Disposable, ExtensionContext, workspace, window, commands, TextDocumentContentProvider, Uri, languages } from 'vscode';
 import { csharpLsVersion } from './constants/csharpLsVersion';
 
 let client: LanguageClient | undefined = undefined;
+let configChangeListener: Disposable | undefined = undefined;
 
 class MetadataUriFeature implements StaticFeature {
     fillClientCapabilities(capabilities: ClientCapabilities): void {
@@ -66,7 +67,26 @@ export async function startCSharpLsServer(
         documentSelector: [{ scheme: 'file', language: 'csharp' }],
         synchronize: {
             fileEvents: workspace.createFileSystemWatcher('**/.{cs,csproj}')
-        }
+        },
+        middleware: {
+            workspace: {
+                configuration: (params, token, next) => {
+                    return params.items.map(item => {
+                        if (item.section !== 'csharp') {
+                            return next(params, token);
+                        }
+                        const cfg = workspace.getConfiguration('csharp-ls');
+                        return {
+                            applyFormattingOptions: cfg.get<boolean>('applyFormattingOptions', false),
+                            analyzersEnabled: cfg.get<boolean>('analyzersEnabled', false),
+                            razorSupport: true,
+                            useMetadataUris: true,
+                            solutionPathOverride: relativeSolutionPath,
+                        };
+                    });
+                },
+            },
+        },
     };
 
     client = new LanguageClient(
@@ -79,10 +99,22 @@ export async function startCSharpLsServer(
     registerTextDocumentContentProviders();
 
     client.registerFeature(new MetadataUriFeature());
-    client.start();
+    await client.start();
+
+    configChangeListener?.dispose();
+    configChangeListener = workspace.onDidChangeConfiguration(async (e) => {
+        if (e.affectsConfiguration('csharp-ls')) {
+            await client?.sendNotification(DidChangeConfigurationNotification.type, {
+                settings: null,
+            });
+        }
+    });
 }
 
 export async function stopCSharpLsServer(): Promise<void> {
+    configChangeListener?.dispose();
+    configChangeListener = undefined;
+
     if (!client) {
         return;
     }

--- a/src/cSharpLsServer.ts
+++ b/src/cSharpLsServer.ts
@@ -82,6 +82,9 @@ export async function startCSharpLsServer(
                             razorSupport: true,
                             useMetadataUris: true,
                             solutionPathOverride: relativeSolutionPath,
+                            debug: {
+                                debugMode: cfg.get<boolean>('debugMode', false),
+                            },
                         };
                     });
                 },

--- a/src/cSharpLsServer.ts
+++ b/src/cSharpLsServer.ts
@@ -153,7 +153,7 @@ async function ensureWeHaveDotnet() {
     }
 
     if (!dotnetVersion) {
-        throw new Error('Failed to get dotnet version. Make sure dotnet is installed and in vscode PATH');
+        throw new Error('Failed to get dotnet version. Make sure dotnet SDK is installed and in vscode PATH');
     }
 
     const dotnetVersionParts = dotnetVersion.split('.');
@@ -163,8 +163,8 @@ async function ensureWeHaveDotnet() {
         throw new Error(`Failed to parse dotnet version: ${dotnetVersion}`);
     }
 
-    if (majorVersion < 8) {
-        throw new Error(`csharp-ls requires dotnet version 8.0 or higher. Current version is ${dotnetVersion}`);
+    if (majorVersion < 10) {
+        throw new Error(`csharp-ls requires dotnet SDK version 10.0 or higher. Current version is ${dotnetVersion}`);
     }
 }
 

--- a/src/cSharpLsServer.ts
+++ b/src/cSharpLsServer.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { mkdir } from 'fs/promises';
 import { LanguageClient, LanguageClientOptions, ServerOptions, StaticFeature } from 'vscode-languageclient/node';
 import { ChildProcess, spawn } from 'child_process';
@@ -32,19 +33,27 @@ export async function startCSharpLsServer(
     const rootPath = slnWorkspaceFolder?.uri.fsPath ?? workspace.rootPath ?? '';
     const relativeSolutionPath = solutionPath.replace(rootPath, '').replace(/^[\/\\]/, '');
 
-    // Build features flag
-    const features: string[] = [];
+    // Build args array
+    const args: string[] = ['--solution', relativeSolutionPath];
+
     const razorSupport = workspace.getConfiguration('csharp-ls').get('razor-support') as boolean;
     if (razorSupport) {
-        features.push('razor-support');
+        args.push('--features', 'razor-support');
     }
-    const featuresFlag = features.length > 0 ? `--features ${features.join(',')}` : '';
+
+    const rpcLogRaw = workspace.getConfiguration('csharp-ls').get('rpcLog') as string;
+    const rpcLog = rpcLogRaw?.startsWith('~')
+        ? path.join(os.homedir(), rpcLogRaw.slice(1))
+        : rpcLogRaw;
+    if (rpcLog) {
+        args.push('--rpclog', rpcLog);
+    }
 
     const csharpLsExecutable = {
-        command: `${csharpLsBinaryPath} --solution ${relativeSolutionPath} ${featuresFlag}`,
+        command: csharpLsBinaryPath,
+        args,
         options: {
             cwd: rootPath,
-            shell: true,
         },
     };
 


### PR DESCRIPTION
This is to go with csharp-ls 0.24.0

## Summary

- Replace `csharp-ls.razor-support` config with a hardcoded `razorSupport: true` in the workspace configuration middleware, so Razor support is always on without a separate toggle
- Add workspace configuration middleware that maps `csharp-ls.*` VS Code settings into the `csharp` section expected by csharp-ls, and send `DidChangeConfigurationNotification` on config changes for live updates without a restart
- Add `csharp-ls.debugMode` boolean setting (default: `false`) — enables debug mode on the server, which logs periodic request queue statistics (`csharp.debug.debugMode`)

## Test plan

- [ ] Open a C# workspace and confirm the language server starts correctly
- [ ] Toggle `csharp-ls.applyFormattingOptions`, `csharp-ls.analyzersEnabled`, and `csharp-ls.debugMode` and verify the server picks up changes without a restart
- [ ] Confirm Razor (`.cshtml`) files still get language features without needing to enable any setting

🤖 Generated with [eca](https://eca.dev)